### PR TITLE
Fix: Vitepres TypeError CSS

### DIFF
--- a/apps/docs/pages/.vitepress/config.ts
+++ b/apps/docs/pages/.vitepress/config.ts
@@ -28,6 +28,9 @@ export default defineConfig({
     ],
   },
   vite: {
+    ssr: {
+      noExternal: ['vuetify'],
+    },
     plugins: [
       vuetify(),
       Unocss({


### PR DESCRIPTION
Fix for Vitepres TypeError [ERR_UNKNOWN_FILE_EXTENSION]: Unknown file extension ".css".

Source: https://github.com/vuetifyjs/vuetify/discussions/15735